### PR TITLE
Update databases on page reload

### DIFF
--- a/lib/sequenceserver/routes.rb
+++ b/lib/sequenceserver/routes.rb
@@ -56,6 +56,7 @@ module SequenceServer
 
     # Returns base HTML. Rest happens client-side: rendering the search form.
     get '/' do
+      Database.scan_databases_dir
       erb :search, layout: true
     end
 


### PR DESCRIPTION
Currently, when we add a new database, we must kill the server and start it again so the change shows up on the page. This means a downtime for the server. Here, we suggest adding a line to scan the databases on page reload.